### PR TITLE
add guard and early exit if source and destination only differ by trailing slash

### DIFF
--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -1964,7 +1964,7 @@ function copy_dir( $from, $to, $skip_list = array() ) {
  * @param bool   $overwrite Optional. Whether to overwrite the destination directory if it exists.
  *                          Default false.
 
- * @return true|WP_Error True on success, WP_Error on failure.
+ * @return bool|WP_Error True on success, False or WP_Error on failure.
  */
 function move_dir( $from, $to, $overwrite = false ) {
 	global $wp_filesystem;
@@ -1978,6 +1978,10 @@ function move_dir( $from, $to, $overwrite = false ) {
 				"<code>$to</code>"
 			)
 		);
+	}
+
+	if ( trailingslashit( $from ) === trailingslashit( $to ) ) {
+		return false;
 	}
 
 	if ( $wp_filesystem->move( $from, $to, $overwrite ) ) {

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -1964,7 +1964,7 @@ function copy_dir( $from, $to, $skip_list = array() ) {
  * @param bool   $overwrite Optional. Whether to overwrite the destination directory if it exists.
  *                          Default false.
 
- * @return bool|WP_Error True on success, False or WP_Error on failure.
+ * @return true|WP_Error True on success, WP_Error on failure.
  */
 function move_dir( $from, $to, $overwrite = false ) {
 	global $wp_filesystem;
@@ -1981,7 +1981,10 @@ function move_dir( $from, $to, $overwrite = false ) {
 	}
 
 	if ( trailingslashit( $from ) === trailingslashit( $to ) ) {
-		return false;
+		return new WP_Error(
+			'source_destination_same_move_dir',
+			__( 'The source and destination are the same.' )
+		);
 	}
 
 	if ( $wp_filesystem->move( $from, $to, $overwrite ) ) {

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -1980,7 +1980,7 @@ function move_dir( $from, $to, $overwrite = false ) {
 		);
 	}
 
-	if ( trailingslashit( $from ) === trailingslashit( $to ) ) {
+	if ( trailingslashit( strtolower( $from ) ) === trailingslashit( strtolower( $to ) ) ) {
 		return new WP_Error(
 			'source_destination_same_move_dir',
 			__( 'The source and destination are the same.' )


### PR DESCRIPTION
I can across an edge case where the only difference between the source and the destination is a trailing slash. This will cause the source to be deleted as the destination is deleted.

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
