### PR TITLE
Login and Registration: Add expiration support for dismissing notices.

### DIFF
--- a/src/js/_enqueues/admin/common.js
+++ b/src/js/_enqueues/admin/common.js
@@ -1109,11 +1109,46 @@ $( function() {
 			$button.find( '.screen-reader-text' ).text( __( 'Dismiss this notice.' ) );
 			$button.on( 'click.wp-dismiss-notice', function( event ) {
 				event.preventDefault();
-				$el.fadeTo( 100, 0, function() {
-					$el.slideUp( 100, function() {
-						$el.remove();
+
+				var $dismiss_data = { action: 'dismiss-notice' },
+				    $slug = $el.data( 'slug' ),
+				    $expiration = $el.data( 'expiration' );
+
+				if ( ! $slug ) {
+					$el.fadeTo( 100, 0, function() {
+						$el.slideUp( 100, function() {
+							$el.remove();
+						});
 					});
-				});
+				} else {
+					$dismiss_data.slug = $slug;
+
+					if ( $expiration ) {
+						$dismiss_data.expiration = $expiration;
+					}
+
+					$.post(
+						ajaxurl,
+						$dismiss_data
+					).always( function ( response ) {
+						if ( true === response.success ) {
+							$el.fadeTo( 100, 0, function() {
+								$el.slideUp( 100, function() {
+									$el.remove();
+								});
+							});
+						} else {
+							var $noticeDismissalFailed = $( '#notice-dismissal-failed' );
+
+							if ( 0 === $noticeDismissalFailed.length ) {
+								$el.after( '<div id="notice-dismissal-failed" class="notice notice-error"><p>' + response.data + '</p></div>' );
+							} else {
+								$el.after( $noticeDismissalFailed );
+								$noticeDismissalFailed.find( 'p' ).innerHTML = response.data;
+							}
+						}
+					} );
+				}
 			});
 
 			$el.append( $button );
@@ -1733,7 +1768,7 @@ $( function() {
 						setTimeout( function() {
 							var focusIsInToggle  = $.contains( toggleButton, focusedElement );
 							var focusIsInSidebar = $.contains( sidebar, focusedElement );
-							
+
 							if ( ! focusIsInToggle && ! focusIsInSidebar ) {
 								$( toggleButton ).trigger( 'click.wp-responsive' );
 							}

--- a/src/wp-admin/admin-ajax.php
+++ b/src/wp-admin/admin-ajax.php
@@ -141,6 +141,7 @@ $core_actions_post = array(
 	'health-check-get-sizes',
 	'toggle-auto-updates',
 	'send-password-reset',
+	'dismiss-notice',
 );
 
 // Deprecated.

--- a/tests/phpunit/includes/testcase-ajax.php
+++ b/tests/phpunit/includes/testcase-ajax.php
@@ -113,6 +113,7 @@ abstract class WP_Ajax_UnitTestCase extends WP_UnitTestCase {
 		'get-post-thumbnail-html',
 		'wp-privacy-export-personal-data',
 		'wp-privacy-erase-personal-data',
+		'dismiss-notice',
 	);
 
 	public static function set_up_before_class() {

--- a/tests/phpunit/tests/ajax/wpAjaxDismissNotice.php
+++ b/tests/phpunit/tests/ajax/wpAjaxDismissNotice.php
@@ -1,0 +1,412 @@
+<?php
+/**
+ * Admin Ajax functions to be tested.
+ */
+require_once ABSPATH . 'wp-admin/includes/ajax-actions.php';
+
+/**
+ * Tests for wp_ajax_dismiss_notice().
+ *
+ * @group ajax
+ *
+ * @covers ::wp_ajax_dismiss_notice
+ */
+class Tests_Ajax_WpAjaxDismissNotice extends WP_Ajax_UnitTestCase {
+
+	/**
+	 * Tests that a notice is dismissed.
+	 *
+	 * @ticket
+	 *
+	 * @dataProvider data_should_dismiss_notice
+	 *
+	 * @param string     $slug       The slug of the notice.
+	 * @param int|string $expiration Time until expiration in seconds. 0 = no expiration (permanent).
+	 *                               'skip' to skip adding the 'expiration' request parameter.
+	 */
+	public function test_should_dismiss_notice( $slug, $expiration ) {
+		// Become an administrator.
+		$this->_setRole( 'administrator' );
+
+		// Set up a default request.
+		$_POST['nonce'] = wp_create_nonce( 'dismiss-notice' );
+		$_POST['slug']  = $slug;
+
+		if ( 'skip' !== $expiration ) {
+			$_POST['expiration'] = $expiration;
+		}
+
+		// Make the request.
+		try {
+			$this->_handleAjax( 'dismiss-notice' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			unset( $e );
+		}
+
+		// Get the response.
+		$response = json_decode( $this->_last_response, true );
+
+		$this->assertTrue(
+			$response['success'],
+			'The notice was not dismissed.'
+		);
+
+		$this->assertSame(
+			'The notice was successfully dismissed.',
+			$response['data'],
+			'An unexpected JSON success message was received.'
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_should_dismiss_notice() {
+		return array(
+			'no expiration provided (should be permanent)' => array(
+				'slug'       => 'mynotice-dismiss-forever-default',
+				'expiration' => 'skip',
+			),
+			'an expiration of 0 seconds (permanent)'       => array(
+				'slug'       => 'mynotice-dismiss-forever-specified',
+				'expiration' => 0,
+			),
+			'an expiration of 30 days'                     => array(
+				'slug'       => 'mynotice-dismiss-for-30-days',
+				'expiration' => 30 * DAY_IN_SECONDS,
+			),
+			'a (bool) true slug' => array(
+				'slug'       => true,
+				'expiration' => 0,
+				'expected'   => "Failed to dismiss notice: The notice's slug must not be an empty string.",
+			),
+			'an (int) 1 slug' => array(
+				'slug'       => 1,
+				'expiration' => 0,
+			),
+			'an (int) 0 slug' => array(
+				'slug'       => 0,
+				'expiration' => 0,
+			),
+			'a (float) 1.0 slug' => array(
+				'slug'       => 1.0,
+				'expiration' => 0,
+			),
+			'a (float) 0.0 slug' => array(
+				'slug'       => 0.0,
+				'expiration' => 0,
+			),
+			'a NULL "expiration" value' => array(
+				'slug'       => 'mynotice',
+				'expiration' => null,
+			),
+			'a (float) 1.0 "expiration" value' => array(
+				'slug'       => 'mynotice',
+				'expiration' => 1.0,
+			),
+			'a (float) 0.0 "expiration" value' => array(
+				'slug'       => 'mynotice',
+				'expiration' => 0.0,
+			),
+			'a (string) "1" "expiration" value'            => array(
+				'slug'       => 'mynotice',
+				'expiration' => '1',
+			),
+			'a (string) "0" "expiration" value'            => array(
+				'slug'       => 'mynotice',
+				'expiration' => '0',
+			),
+			'a NAN "expiration" value' => array(
+				'slug'       => 'mynotice',
+				'expiration' => NAN,
+			),
+			'an INF "expiration" value' => array(
+				'slug'       => 'mynotice',
+				'expiration' => INF,
+			),
+		);
+	}
+
+	/**
+	 * Tests that a notice with an invalid slug is not dismissed.
+	 *
+	 * @ticket
+	 *
+	 * @dataProvider data_should_not_dismiss_notice_with_invalid_slug
+	 *
+	 * @param mixed      $slug       The slug of the notice.
+	 *                               'skip' to skip adding the 'slug' request parameter.
+	 * @param int|string $expiration Time until expiration in seconds. 0 = no expiration (permanent).
+	 *                               'skip' to skip adding the 'expiration' request parameter.
+	 * @param string     $expected   The expected JSON error.
+	 */
+	public function test_should_not_dismiss_notice_with_invalid_slug( $slug, $expiration, $expected ) {
+		// Become an administrator.
+		$this->_setRole( 'administrator' );
+
+		// Set up a default request.
+		$_POST['nonce'] = wp_create_nonce( 'dismiss-notice' );
+
+		if ( 'skip' !== $slug ) {
+			$_POST['slug'] = $slug;
+		}
+
+		if ( 'skip' !== $expiration ) {
+			$_POST['expiration'] = $expiration;
+		}
+
+		// Make the request.
+		try {
+			$this->_handleAjax( 'dismiss-notice' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			unset( $e );
+		}
+
+		// Get the response.
+		$response = json_decode( $this->_last_response, true );
+
+		$this->assertFalse(
+			$response['success'],
+			'The notice was dismissed.'
+		);
+
+		$this->assertSame(
+			$expected,
+			$response['data'],
+			'An unexpected JSON error message was received.'
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_should_not_dismiss_notice_with_invalid_slug() {
+		return array(
+			'an empty "dismissible" array'                 => array(
+				'slug'       => 'skip',
+				'expiration' => 'skip',
+				'expected'   => 'Failed to dismiss notice: The notice does not have a slug.',
+			),
+			'no "slug" key in the "dismissible" array'     => array(
+				'slug'       => 'skip',
+				'expiration' => 0,
+				'expected'   => 'Failed to dismiss notice: The notice does not have a slug.',
+			),
+			'a NULL "slug" key in the "dismissible" array' => array(
+				'slug'       => null,
+				'expiration' => 0,
+				'expected'   => 'Failed to dismiss notice: The notice does not have a slug.',
+			),
+			'a (bool) false "slug" key in the "dismissible" array' => array(
+				'slug'       => false,
+				'expiration' => 0,
+				'expected'   => "Failed to dismiss notice: The notice's slug must not be an empty string.",
+			),
+			'an empty array "slug" key in the "dismissible" array' => array(
+				'slug'       => array(),
+				'expiration' => 0,
+				'expected'   => "Failed to dismiss notice: The notice's slug must not be an empty string.",
+			),
+			'a populated array "slug" key in the "dismissible" array' => array(
+				'slug'       => array( 'mynotice-dismiss-forever' ),
+				'expiration' => 0,
+				'expected'   => "Failed to dismiss notice: The notice's slug must not be an empty string.",
+			),
+			'an object "slug" key in the "dismissible" array' => array(
+				'slug'       => new stdClass(),
+				'expiration' => 0,
+				'expected'   => "Failed to dismiss notice: The notice's slug must not be an empty string.",
+			),
+			'an empty string "slug" key in the "dismissible" array' => array(
+				'slug'       => '',
+				'expiration' => 0,
+				'expected'   => "Failed to dismiss notice: The notice's slug must not be an empty string.",
+			),
+			'a "slug" key containing only space in the "dismissible" array' => array(
+				'slug'       => " \r\t\n",
+				'expiration' => 0,
+				'expected'   => "Failed to dismiss notice: The notice's slug must not be an empty string.",
+			),
+		);
+	}
+
+	/**
+	 * Tests that a notice with an invalid slug is not dismissed.
+	 *
+	 * @ticket
+	 *
+	 * @dataProvider data_should_not_dismiss_notice_with_invalid_expiration
+	 *
+	 * @param mixed  $expiration Time until expiration in seconds. 0 = no expiration (permanent).
+	 * @param string $expected   The expected JSON error.
+	 */
+	public function test_should_not_dismiss_notice_with_invalid_expiration( $expiration, $expected ) {
+		// Become an administrator.
+		$this->_setRole( 'administrator' );
+
+		// Set up a default request.
+		$_POST['nonce']      = wp_create_nonce( 'dismiss-notice' );
+		$_POST['slug']       = 'mynotice';
+		$_POST['expiration'] = $expiration;
+
+		// Make the request.
+		try {
+			$this->_handleAjax( 'dismiss-notice' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			unset( $e );
+		}
+
+		// Get the response.
+		$response = json_decode( $this->_last_response, true );
+
+		$this->assertFalse(
+			$response['success'],
+			'The notice was dismissed.'
+		);
+
+		$this->assertSame(
+			$expected,
+			$response['data'],
+			'An unexpected JSON error message was received.'
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_should_not_dismiss_notice_with_invalid_expiration() {
+		return array(
+			'a (bool) false "expiration" value'    => array(
+				'expiration' => false,
+				'expected'   => 'Failed to dismiss notice: The expiration time must be a number of seconds.',
+			),
+			'a (bool) true "expiration" value'     => array(
+				'expiration' => true,
+				'expected'   => 'Failed to dismiss notice: The expiration time must be a number of seconds.',
+			),
+			'an empty array "expiration" value'    => array(
+				'expiration' => array(),
+				'expected'   => 'Failed to dismiss notice: The expiration time must be a number of seconds.',
+			),
+			'a populated array "expiration" value' => array(
+				'expiration' => array( 1 ),
+				'expected'   => 'Failed to dismiss notice: The expiration time must be a number of seconds.',
+			),
+			'an object "expiration" value'         => array(
+				'expiration' => new stdClass(),
+				'expected'   => 'Failed to dismiss notice: The expiration time must be a number of seconds.',
+			),
+			'a (string) "-1" "expiration" value'   => array(
+				'expiration' => '-1',
+				'expected'   => 'Failed to dismiss notice: The expiration time must be greater than or equal to 0.',
+			),
+			'a negative "expiration" value'        => array(
+				'expiration' => -1,
+				'expected'   => 'Failed to dismiss notice: The expiration time must be greater than or equal to 0.',
+			),
+		);
+	}
+
+	/**
+	 * Tests that a notice with an invalid nonce is not dismissed.
+	 *
+	 * @ticket
+	 *
+	 * @dataProvider data_should_not_dismiss_notice_with_invalid_nonce
+	 *
+	 * @param string $nonce The nonce for the request.
+	 *                      'skip' to skip adding the request parameter.
+	 */
+	public function test_should_not_dismiss_notice_with_invalid_nonce( $nonce ) {
+		// Become an administrator.
+		$this->_setRole( 'administrator' );
+
+		// Set up a default request.
+		if ( 'skip' !== $nonce ) {
+			$_POST['nonce'] = $nonce;
+		}
+
+		$_POST['slug']       = 'mynotice';
+		$_POST['expiration'] = 0;
+
+		// Make the request.
+		$this->expectException( 'WPAjaxDieStopException', 'The request did not die.' );
+		$this->expectExceptionMessage( '-1', 'An unexpected exception was thrown.' );
+		$this->_handleAjax( 'dismiss-notice' );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_should_not_dismiss_notice_with_invalid_nonce() {
+		return array(
+			'no nonce'                 => array(
+				'nonce' => 'skip',
+			),
+			'nonce for another action' => array(
+				'nonce' => wp_create_nonce( 'my-other-action' ),
+			),
+		);
+	}
+
+	/**
+	 * Tests that a notice is not dismissed for a non-privileged user.
+	 *
+	 * @ticket
+	 */
+	public function test_should_not_dismiss_notice_for_a_non_privileged_user() {
+		// Set up a default request.
+		$_POST['nonce']      = wp_create_nonce( 'dismiss-notice' );
+		$_POST['slug']       = 'mynotice';
+		$_POST['expiration'] = 0;
+
+		// Make the request.
+		$this->expectException( 'WPAjaxDieContinueException', 'The request did not die and continue.' );
+		$this->expectExceptionMessage( '', 'An unexpected exception was thrown.' );
+		$this->_handleAjax( 'dismiss-notice' );
+	}
+
+	/**
+	 * Tests that a notice is not dismissed that is already dismissed.
+	 *
+	 * @ticket
+	 */
+	public function test_should_not_dismiss_notice_that_is_already_dismissed() {
+		// Dismiss the notice.
+		set_site_transient( 'wp_admin_notice_dismissed_mynotice', 1 );
+
+		// Set up a default request.
+		$_POST['nonce']      = wp_create_nonce( 'dismiss-notice' );
+		$_POST['slug']       = 'mynotice';
+		$_POST['expiration'] = 0;
+
+		// Make the request.
+		try {
+			$this->_handleAjax( 'dismiss-notice' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			unset( $e );
+		}
+
+		// Get the response.
+		$response = json_decode( $this->_last_response, true );
+
+		$this->assertFalse(
+			$response['success'],
+			'The notice was dismissed.'
+		);
+
+		$this->assertSame(
+			'Failed to dismiss notice: The notice could not be dismissed.',
+			$response['data'],
+			'An unexpected JSON error message was received.'
+		);
+	}
+}

--- a/tests/phpunit/tests/functions/wpAdminNotice.php
+++ b/tests/phpunit/tests/functions/wpAdminNotice.php
@@ -284,6 +284,25 @@ class Tests_Functions_WpAdminNotice extends WP_UnitTestCase {
 				),
 				'expected' => '<div class="notice"><p>A notice with paragraph wrapping as a falsy value rather than (bool) false.</p></div>',
 			),
+			'a notice that should be dismissed permanently' => array(
+				'message'  => 'A notice that should be dismissed permanently.',
+				'args'     => array(
+					'dismissible' => array(
+						'slug' => 'mynotice-dismiss-permanently',
+					),
+				),
+				'expected' => '<div class="notice is-dismissible" data-slug="mynotice-dismiss-permanently"><p>A notice that should be dismissed permanently.</p></div>',
+			),
+			'a notice that should be dismissed for 30 days' => array(
+				'message'  => 'A notice that should be dismissed for 30 days.',
+				'args'     => array(
+					'dismissible' => array(
+						'slug'       => 'mynotice-dismiss-for-30-days',
+						'expiration' => 30 * DAY_IN_SECONDS,
+					),
+				),
+				'expected' => '<div class="notice is-dismissible" data-slug="mynotice-dismiss-for-30-days" data-expiration="2592000"><p>A notice that should be dismissed for 30 days.</p></div>',
+			),
 		);
 	}
 
@@ -322,5 +341,326 @@ class Tests_Functions_WpAdminNotice extends WP_UnitTestCase {
 		ob_end_clean();
 
 		$this->assertSame( 1, $action->get_call_count() );
+	}
+
+
+	/**
+	 * Tests that `wp_admin_notice()` outputs an empty string for a notice that is still dismissed.
+	 *
+	 * @ticket
+	 *
+	 * @dataProvider data_notices_with_dismissible_array
+	 *
+	 * @param array $dismissible The value for the dismissible array.
+	 */
+	public function test_should_output_empty_string_for_a_notice_that_is_still_dismissed( $dismissible ) {
+		// The notice is still dismissed.
+		set_site_transient( 'wp_admin_notice_dismissed_' . $dismissible['slug'], 1 );
+
+		ob_start();
+		wp_admin_notice(
+			'A notice that is still dismissed.',
+			array(
+				'dismissible' => $dismissible,
+			)
+		);
+		$actual = ob_get_clean();
+
+		$this->assertSame( '', $actual );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_notices_with_dismissible_array() {
+		return array(
+			'a permanently dismissed notice (slug only, no expiration provided)' => array(
+				'dismissible' => array(
+					'slug' => 'mynotice-dismiss-forever',
+				),
+			),
+			'a notice dismissed for 30 days' => array(
+				'dismissible' => array(
+					'slug'       => 'mynotice-dismiss-for-30-days',
+					'expiration' => 30 * DAY_IN_SECONDS,
+				),
+			),
+		);
+	}
+
+	/**
+	 * Tests that `wp_admin_notice()` triggers an error.
+	 *
+	 * @ticket
+	 *
+	 * @dataProvider data_should_trigger_error_for_an_invalid_dismissible_slug
+	 * @dataProvider data_should_trigger_error_for_invalid_dismissible_expiration
+	 *
+	 * @param string $message         The message.
+	 * @param array  $args            Arguments for the admin notice.
+	 * @param string $expected_markup The expected admin notice markup.
+	 * @param string $expected_error  The expected error message.
+	 */
+	public function test_should_trigger_error( $message, $args, $expected_markup, $expected_error ) {
+		// Ensure no previous errors exist.
+		error_clear_last();
+
+		// Backup the error reporting value.
+		$original_error_reporting = error_reporting();
+
+		// Suppress E_USER_NOTICE.
+		error_reporting( E_ALL & ~E_USER_NOTICE );
+
+		ob_start();
+		wp_admin_notice( $message, $args );
+		$actual     = ob_get_clean();
+		$last_error = error_get_last();
+
+		// Reset error reporting.
+		error_reporting( $original_error_reporting );
+
+		$this->assertSame( $expected_markup, $actual );
+		$this->assertIsArray( $last_error, 'An error was not triggered.' );
+		$this->assertSame( E_USER_NOTICE, $last_error['type'], 'The error was not a notice.' );
+		$this->assertSame( $last_error['message'], 'wp_get_admin_notice(): ' . $expected_error, 'The wrong error message was sent.' );
+	}
+
+		/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_should_trigger_error_for_an_invalid_dismissible_slug() {
+		return array(
+			'an empty "dismissible" array'                 => array(
+				'message'         => 'an empty "dismissible" array',
+				'args'            => array(
+					'dismissible' => array(),
+				),
+				'expected_markup' => '<div class="notice"><p>an empty "dismissible" array</p></div>',
+				'expected_error'  => 'The "slug" key in the "dismissible" array must be a string.',
+			),
+			'no "slug" key in the "dismissible" array'     => array(
+				'message'         => 'no "slug" key in the "dismissible" array',
+				'args'            => array(
+					'dismissible' => array( 'expiration' => 30 * DAY_IN_SECONDS ),
+				),
+				'expected_markup' => '<div class="notice"><p>no "slug" key in the "dismissible" array</p></div>',
+				'expected_error'  => 'The "slug" key in the "dismissible" array must be a string.',
+			),
+			'a NULL "slug" key in the "dismissible" array' => array(
+				'message'         => 'a NULL "slug" key in the "dismissible" array',
+				'args'            => array(
+					'dismissible' => array( 'slug' => null ),
+				),
+				'expected_markup' => '<div class="notice"><p>a NULL "slug" key in the "dismissible" array</p></div>',
+				'expected_error'  => 'The "slug" key in the "dismissible" array must be a string.',
+			),
+			'a (bool) false "slug" key in the "dismissible" array' => array(
+				'message'         => 'a (bool) false "slug" key in the "dismissible" array',
+				'args'            => array(
+					'dismissible' => array( 'slug' => false ),
+				),
+				'expected_markup' => '<div class="notice"><p>a (bool) false "slug" key in the "dismissible" array</p></div>',
+				'expected_error'  => 'The "slug" key in the "dismissible" array must be a string.',
+			),
+			'a (bool) true "slug" key in the "dismissible" array' => array(
+				'message'         => 'a (bool) true "slug" key in the "dismissible" array',
+				'args'            => array(
+					'dismissible' => array( 'slug' => true ),
+				),
+				'expected_markup' => '<div class="notice"><p>a (bool) true "slug" key in the "dismissible" array</p></div>',
+				'expected_error'  => 'The "slug" key in the "dismissible" array must be a string.',
+			),
+			'an integer "slug" key in the "dismissible" array' => array(
+				'message'         => 'an integer "slug" key in the "dismissible" array',
+				'args'            => array(
+					'dismissible' => array( 'slug' => 1234 ),
+				),
+				'expected_markup' => '<div class="notice"><p>an integer "slug" key in the "dismissible" array</p></div>',
+				'expected_error'  => 'The "slug" key in the "dismissible" array must be a string.',
+			),
+			'a float "slug" key in the "dismissible" array' => array(
+				'message'         => 'a float "slug" key in the "dismissible" array',
+				'args'            => array(
+					'dismissible' => array( 'slug' => 12.34 ),
+				),
+				'expected_markup' => '<div class="notice"><p>a float "slug" key in the "dismissible" array</p></div>',
+				'expected_error'  => 'The "slug" key in the "dismissible" array must be a string.',
+			),
+			'an empty array "slug" key in the "dismissible" array' => array(
+				'message'         => 'an empty array "slug" key in the "dismissible" array',
+				'args'            => array(
+					'dismissible' => array( 'slug' => array() ),
+				),
+				'expected_markup' => '<div class="notice"><p>an empty array "slug" key in the "dismissible" array</p></div>',
+				'expected_error'  => 'The "slug" key in the "dismissible" array must be a string.',
+			),
+			'a populated array "slug" key in the "dismissible" array' => array(
+				'message'         => 'a populated array "slug" key in the "dismissible" array',
+				'args'            => array(
+					'dismissible' => array( 'slug' => array( 'mynotice-dismiss-forever' ) ),
+				),
+				'expected_markup' => '<div class="notice"><p>a populated array "slug" key in the "dismissible" array</p></div>',
+				'expected_error'  => 'The "slug" key in the "dismissible" array must be a string.',
+			),
+			'an object "slug" key in the "dismissible" array' => array(
+				'message'         => 'an object "slug" key in the "dismissible" array',
+				'args'            => array(
+					'dismissible' => array( 'slug' => new stdClass() ),
+				),
+				'expected_markup' => '<div class="notice"><p>an object "slug" key in the "dismissible" array</p></div>',
+				'expected_error'  => 'The "slug" key in the "dismissible" array must be a string.',
+			),
+			'an empty string "slug" key in the "dismissible" array' => array(
+				'message'         => 'an empty string "slug" key in the "dismissible" array',
+				'args'            => array(
+					'dismissible' => array( 'slug' => '' ),
+				),
+				'expected_markup' => '<div class="notice"><p>an empty string "slug" key in the "dismissible" array</p></div>',
+				'expected_error'  => 'The "slug" key in the "dismissible" array must be a non-empty string.',
+			),
+			'a "slug" key containing only space in the "dismissible" array' => array(
+				'message'         => 'a "slug" key containing only space in the "dismissible" array',
+				'args'            => array(
+					'dismissible' => array( 'slug' => " \r\t\n" ),
+				),
+				'expected_markup' => '<div class="notice"><p>a "slug" key containing only space in the "dismissible" array</p></div>',
+				'expected_error'  => 'The "slug" key in the "dismissible" array must be a non-empty string.',
+			),
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_should_trigger_error_for_invalid_dismissible_expiration() {
+		return array(
+			'a NULL "expiration" value in the "dismissible" array' => array(
+				'message'         => 'a null "expiration" value in the "dismissible" array',
+				'args'            => array(
+					'dismissible' => array(
+						'slug'       => 'mynotice-null-expiration',
+						'expiration' => null,
+					),
+				),
+				'expected_markup' => '<div class="notice"><p>a null "expiration" value in the "dismissible" array</p></div>',
+				'expected_error'  => 'The "expiration" key in the "dismissible" array must be an integer.',
+			),
+			'a (bool) false "expiration" value in the "dismissible" array' => array(
+				'message'         => 'a (bool) false "expiration" value in the "dismissible" array',
+				'args'            => array(
+					'dismissible' => array(
+						'slug'       => 'mynotice-false-expiration',
+						'expiration' => false,
+					),
+				),
+				'expected_markup' => '<div class="notice"><p>a (bool) false "expiration" value in the "dismissible" array</p></div>',
+				'expected_error'  => 'The "expiration" key in the "dismissible" array must be an integer.',
+			),
+			'a (bool) true "expiration" value in the "dismissible" array' => array(
+				'message'         => 'a (bool) true "expiration" value in the "dismissible" array',
+				'args'            => array(
+					'dismissible' => array(
+						'slug'       => 'mynotice-true-expiration',
+						'expiration' => true,
+					),
+				),
+				'expected_markup' => '<div class="notice"><p>a (bool) true "expiration" value in the "dismissible" array</p></div>',
+				'expected_error'  => 'The "expiration" key in the "dismissible" array must be an integer.',
+			),
+			'an empty array "expiration" value in the "dismissible" array' => array(
+				'message'         => 'an empty array "expiration" value in the "dismissible" array',
+				'args'            => array(
+					'dismissible' => array(
+						'slug'       => 'mynotice-empty-array-expiration',
+						'expiration' => array(),
+					),
+				),
+				'expected_markup' => '<div class="notice"><p>an empty array "expiration" value in the "dismissible" array</p></div>',
+				'expected_error'  => 'The "expiration" key in the "dismissible" array must be an integer.',
+			),
+			'a populated array "expiration" value in the "dismissible" array' => array(
+				'message'         => 'a populated array "expiration" value in the "dismissible" array',
+				'args'            => array(
+					'dismissible' => array(
+						'slug'       => 'mynotice-populated-array-expiration',
+						'expiration' => array( 30 * DAY_IN_SECONDS ),
+					),
+				),
+				'expected_markup' => '<div class="notice"><p>a populated array "expiration" value in the "dismissible" array</p></div>',
+				'expected_error'  => 'The "expiration" key in the "dismissible" array must be an integer.',
+			),
+			'an object "expiration" value in the "dismissible" array' => array(
+				'message'         => 'an object "expiration" value in the "dismissible" array',
+				'args'            => array(
+					'dismissible' => array(
+						'slug'       => 'mynotice-object-expiration',
+						'expiration' => array( 30 * DAY_IN_SECONDS ),
+					),
+				),
+				'expected_markup' => '<div class="notice"><p>an object "expiration" value in the "dismissible" array</p></div>',
+				'expected_error'  => 'The "expiration" key in the "dismissible" array must be an integer.',
+			),
+			'a float "expiration" value in the "dismissible" array' => array(
+				'message'         => 'a float "expiration" value in the "dismissible" array',
+				'args'            => array(
+					'dismissible' => array(
+						'slug'       => 'mynotice-float-expiration',
+						'expiration' => 30.0,
+					),
+				),
+				'expected_markup' => '<div class="notice"><p>a float "expiration" value in the "dismissible" array</p></div>',
+				'expected_error'  => 'The "expiration" key in the "dismissible" array must be an integer.',
+			),
+			'a numeric string "expiration" value in the "dismissible" array' => array(
+				'message'         => 'a numeric string "expiration" value in the "dismissible" array',
+				'args'            => array(
+					'dismissible' => array(
+						'slug'       => 'mynotice-numeric-string-expiration',
+						'expiration' => '30',
+					),
+				),
+				'expected_markup' => '<div class="notice"><p>a numeric string "expiration" value in the "dismissible" array</p></div>',
+				'expected_error'  => 'The "expiration" key in the "dismissible" array must be an integer.',
+			),
+			'a NAN "expiration" value in the "dismissible" array' => array(
+				'message'         => 'a NAN "expiration" value in the "dismissible" array',
+				'args'            => array(
+					'dismissible' => array(
+						'slug'       => 'mynotice-nan-expiration',
+						'expiration' => NAN,
+					),
+				),
+				'expected_markup' => '<div class="notice"><p>a NAN "expiration" value in the "dismissible" array</p></div>',
+				'expected_error'  => 'The "expiration" key in the "dismissible" array must be an integer.',
+			),
+			'an INF "expiration" value in the "dismissible" array' => array(
+				'message'         => 'an INF "expiration" value in the "dismissible" array',
+				'args'            => array(
+					'dismissible' => array(
+						'slug'       => 'mynotice-inf-expiration',
+						'expiration' => INF,
+					),
+				),
+				'expected_markup' => '<div class="notice"><p>an INF "expiration" value in the "dismissible" array</p></div>',
+				'expected_error'  => 'The "expiration" key in the "dismissible" array must be an integer.',
+			),
+			'a negative "expiration" value in the "dismissible" array' => array(
+				'message'         => 'a negative "expiration" value in the "dismissible" array',
+				'args'            => array(
+					'dismissible' => array(
+						'slug'       => 'mynotice-negative-expiration',
+						'expiration' => -1,
+					),
+				),
+				'expected_markup' => '<div class="notice"><p>a negative "expiration" value in the "dismissible" array</p></div>',
+				'expected_error'  => 'The "expiration" key in the "dismissible" array must be greater than or equal to 0.',
+			),
+		);
 	}
 }


### PR DESCRIPTION
This adds support for an array `dismissible` value in `wp_get_admin_notice()`.

The array:
```php
array(
    // (string) Required. Cannot be empty.
    'slug'       => 'mynotice',
    // (int) Optional. Seconds to dismiss for. Must be >= 0. Default 0 (permanently dismissed).
    'expiration' => 60,
)
```

## Examples

### Make a notice permanently dismissible

```php
wp_get_admin_notice(
    __( 'A notice that will be dismissed permanently.' ),
   array(
       'type'        => 'info',
       'dismissible' => array( 'slug' => 'mynotice' ),
   )
);
```

### Make a notice dismissible for 30 days

```php
wp_get_admin_notice(
    __( 'A notice that will be dismissed for 30 days.' ),
    array(
        'type'        => 'info',
        'dismissible' => array(
            'slug'       => 'mynotice',
            'expiration' => 30 * DAY_IN_SECONDS,
        ),
    )
);
```

### Make all notices permanently dismissible

```php
add_filter( 'wp_admin_notice_args', 'dismiss_each_admin_notice_permanently', 10, 2 );
function dismiss_each_admin_notice_permanently( $args, $message ) {
    $args['dismissible'] = array(
        'slug'       => md5( $message ), // So its transient is unique to that message.
    );
    return $args;
}
```

### Make all notices dismissible for 30 days

```php
add_filter( 'wp_admin_notice_args', 'dismiss_each_admin_notice_for_30_days', 10, 2 );
function dismiss_each_admin_notice_for_30_days( $args, $message ) {
    $args['dismissible'] = array(
        'slug'       => md5( $message ), // So its transient is unique to that message.
        'expiration' => 30 * DAY_IN_SECONDS,
    );
    return $args;
}
```

Trac ticket: 